### PR TITLE
add avk-emacs-themes.el library

### DIFF
--- a/avk-darkblue-white-theme.el
+++ b/avk-darkblue-white-theme.el
@@ -4,7 +4,7 @@
 
 ;; Author: Alex V. Koval <alex@koval.kharkov.ua>
 ;; Maintainer: Alex V. Koval <alex@koval.kharkov.ua>
-;; URL: https://avkoval@bitbucket.org/avkoval/avk-emacs-themes
+;; Homepage: https://github.com/avkoval/avk-emacs-themes
 ;; Created: 14th June 2015
 ;; Version: 0.2
 ;; Keywords: theme

--- a/avk-darkblue-yellow-theme.el
+++ b/avk-darkblue-yellow-theme.el
@@ -4,7 +4,7 @@
 
 ;; Author: Alex V. Koval <alex@koval.kharkov.ua>
 ;; Maintainer: Alex V. Koval <alex@koval.kharkov.ua>
-;; URL: https://avkoval@bitbucket.org/avkoval/avk-emacs-themes
+;; Homepage: https://github.com/avkoval/avk-emacs-themes
 ;; Created: 14th June 2015
 ;; Version: 0.2
 ;; Keywords: theme

--- a/avk-daylight-theme.el
+++ b/avk-daylight-theme.el
@@ -4,7 +4,7 @@
 
 ;; Author: Alex V. Koval <alex@koval.kharkov.ua>
 ;; Maintainer: Alex V. Koval <alex@koval.kharkov.ua>
-;; URL: https://avkoval@bitbucket.org/avkoval/avk-emacs-themes
+;; Homepage: https://github.com/avkoval/avk-emacs-themes
 ;; Created: 14th June 2015
 ;; Version: 0.2
 ;; Keywords: theme

--- a/avk-emacs-themes.el
+++ b/avk-emacs-themes.el
@@ -1,0 +1,20 @@
+;;; avk-emacs-themes.el --- various themes by Alex V. Koval
+
+;; Copyright (C) 2015 Alex V. Koval
+
+;; Author: Alex V. Koval <alex@koval.kharkov.ua>
+;; Maintainer: Alex V. Koval <alex@koval.kharkov.ua>
+;; Homepage: https://github.com/avkoval/avk-emacs-themes
+;; Created: 14th June 2015
+;; Version: 0.2
+;; Keywords: theme
+
+;;; Commentary:
+;;
+;; Various themes by Alex V. Koval.
+
+;; Code:
+
+(provide 'avk-emacs-themes)
+
+;;; avk-emacs-themes.el ends here


### PR DESCRIPTION
Because package should have a library which matches its name. By the way you should probably change the name to just `avk-themes` (you have to do so in all relevant places including Melpa).

The commentary of that library then appears at https://melpa.org/#/avk-emacs-themes. By the way you should write a better commentary.
